### PR TITLE
Add github workflow to run specs against ruby >= 2.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,15 +4,22 @@ on: [push,pull_request]
 
 jobs:
   rspec:
+    strategy:
+      matrix:
+        ruby: [2.4, 2.5, 2.6, 2.7, 3.0]
+
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.4
+        ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+
     - name: Run tests
       run: bundle exec rake spec

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: Ruby
+
+on: [push,pull_request]
+
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.4
+        bundler-cache: true
+    - name: Run tests
+      run: bundle exec rake spec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     address_composer (0.1.5.pre)
       mustache (~> 1.1)
+      psych (~> 4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -18,6 +19,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    psych (4.0.0)
     rake (13.0.1)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)

--- a/address_composer.gemspec
+++ b/address_composer.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_runtime_dependency "mustache", "~> 1.1"
+  gem.add_runtime_dependency "psych", "~> 4.0"
 
   gem.add_development_dependency "bundler", "~> 1.17"
   gem.add_development_dependency "pry", "~> 0.13"

--- a/lib/address_composer.rb
+++ b/lib/address_composer.rb
@@ -1,11 +1,12 @@
 require "address_composer/version"
 require "yaml"
 require "mustache"
+require "psych"
 require "psych/scala_scanner"
 
 class AddressComposer
   GEM_ROOT = Gem::Specification.find_by_name("address_composer").gem_dir
-  Templates = YAML.load_file(File.join(GEM_ROOT, "address-formatting", "conf", "countries", "worldwide.yaml"))
+  Templates = YAML.load_file(File.join(GEM_ROOT, "address-formatting", "conf", "countries", "worldwide.yaml"), aliases: true)
   ComponentsList = Psych.load_stream(File.read(File.join(GEM_ROOT,"address-formatting", "conf","components.yaml")))
   AllComponents = ComponentsList.map { |h| h["name"] } + ComponentsList.flat_map { |h| h["aliases"] }.compact
   StateCodes = YAML.load_file(File.join(GEM_ROOT, "address-formatting", "conf", "state_codes.yaml"))


### PR DESCRIPTION
This PR includes an updated version of the gem `psych` because the patch from [this another PR](https://github.com/mirubiri/address_composer/pull/6) was working only from `ruby >= 3.0`.

We can check the executed actions at https://github.com/sergiogomez/address_composer/actions