### PR TITLE
Created a shallow copy of the received components

### DIFF
--- a/lib/address_composer.rb
+++ b/lib/address_composer.rb
@@ -25,7 +25,7 @@ class AddressComposer
   attr_accessor :components
 
   def initialize(components)
-    self.components = components
+    self.components = components.dup
   end
 
   def compose

--- a/lib/address_composer.rb
+++ b/lib/address_composer.rb
@@ -26,11 +26,11 @@ class AddressComposer
 
   def initialize(components)
     self.components = components.dup
+
+    normalize_components
   end
 
   def compose
-    normalize_components
-
     if components["country_code"]
       result = Template.render(template, components).squeeze("\n").lstrip.gsub(/\s*\n\s*/, "\n")
       result = post_format_replace(result)


### PR DESCRIPTION
We need to create a shallow copy of the received components to avoid any modification over the original hash.

We are also normalizing the components at the initializer.