### PR TITLE
Replace regex to match only numbers from the country component

### DIFF
--- a/lib/address_composer.rb
+++ b/lib/address_composer.rb
@@ -179,7 +179,7 @@ class AddressComposer
     end
 
     # If country is a number use the state as country
-    if components["country"]&.match?(/^\d+$/) && components["state"]
+    if components["state"] && components["country"]&.match?(/^\d+$/)
       components["country"] = components["state"]
     end
 


### PR DESCRIPTION
Fixes this issue: https://github.com/mirubiri/address_composer/issues/15