### PR TITLE
Update upstream to latest commit

### DIFF
--- a/lib/address_composer.rb
+++ b/lib/address_composer.rb
@@ -50,6 +50,7 @@ class AddressComposer
   def compose
     if components["country_code"]
       result = Template.render(template, components).squeeze("\n").lstrip.gsub(/\s*\n\s*/, "\n")
+      result = clean(result)
       result = post_format_replace(result)
     else
       result = components.values.join(" ")


### PR DESCRIPTION
This PR updates to the latest upstream commit.

I've followed the same that is being done in the perl implementation by OpenCageData and also cleaned after calling the template rendering (https://github.com/OpenCageData/perl-Geo-Address-Formatter/blob/5aa51b70422d795f9326ea8444ad5eabfe06199d/lib/Geo/Address/Formatter.pm#L944)
Otherwise, tests fail for MH due to a double space.